### PR TITLE
Scaling Problem Fix on iPhone 6 Plus and 6S Plus.

### DIFF
--- a/m2048/Sprite Kit/M2Scene.m
+++ b/m2048/Sprite Kit/M2Scene.m
@@ -48,7 +48,7 @@
   UIImage *image = [M2GridView gridImageWithGrid:grid];
   SKTexture *backgroundTexture = [SKTexture textureWithCGImage:image.CGImage];
   _board = [SKSpriteNode spriteNodeWithTexture:backgroundTexture];
-  [_board setScale:0.5];
+  [_board setScale:1/[UIScreen mainScreen].scale]; //This solves the Scaling problem in 6Plus and 6S Plus
   _board.position = CGPointMake(CGRectGetMidX(self.frame), CGRectGetMidY(self.frame));
   [self addChild:_board];
 }


### PR DESCRIPTION
BUG : The problem happened in iPhone 6 Plus and 6S Plus as the scaling is hardcoded for 2x (0.5). So I'm getting the scale dynamically from the device and using.

This fixes the Scaling Problem.